### PR TITLE
Canvas will no longer cover menu

### DIFF
--- a/style.css
+++ b/style.css
@@ -54,6 +54,8 @@ a {
   position: relative;
   width: 100%;
   border: none;
+  height: calc(100vh - 115px); 
+  overflow: auto;
 }
 
 #background-image,


### PR DESCRIPTION
Added the following to the #canvas-wrapper
height: calc(100vh - 115px);
overflow: auto;

Now it will no longer covert the menu and be contained to the canvas wrapper so when menus open they will not overlap
![image](https://user-images.githubusercontent.com/56803536/224877884-e5b24143-687e-4490-90a6-079706d9f286.png)

![image](https://user-images.githubusercontent.com/56803536/224878194-3a23599d-e569-4acf-8e1b-9da2cddec8ee.png)
