### PR TITLE
Let mobile users click

### DIFF
--- a/Script.js
+++ b/Script.js
@@ -37,6 +37,7 @@ const mapSaveSelect = document.getElementById("map-save");
 const pointList = document.getElementById("pointList");
 canvas.width = "0px";
 canvas.height = "0px";
+let drag = false;
 
 // New Button logic and configuration
 newProjectBtn.addEventListener("click", function () {
@@ -179,7 +180,14 @@ canvas.addEventListener("mouseup", function (event) {
 
   if (diffX < delta && diffY < delta) {
     // click event
+    drag = false
+  }else{
+    drag = true
+  }
+  });
 
+canvas.addEventListener("click", function () {
+  if(!drag){
     const x = event.offsetX;
     const y = event.offsetY;
     const scrollX = canvas.scrollLeft;


### PR DESCRIPTION
The click event works for other areas of the program. I have moved the Mouse Dow and Mouse Up detection outside into their own rules and provides a result for a new variable "drag". If the user drags the mouse it will se to True, else will be False.

Only when it is false will the click event continue. This should resolve the issue for mobile users being unable to click on the canvas.

![image](https://user-images.githubusercontent.com/56803536/225600190-58c51f92-eb0d-4874-8da4-226bff044504.png)
