### PR TITLE
63 click on list to copy to clipboard

### DIFF
--- a/Script.js
+++ b/Script.js
@@ -618,10 +618,12 @@ function defaultlistcolour(){
   }
 
 canvas.addEventListener("mousemove", function (event) {
+  
   const x = event.offsetX;
   const y = event.offsetY;
   let circleHovered = false;
 
+  if (!menuOpen){
   for (let i = 0; i < points.length; i++) {
     const point = points[i];
     context.beginPath();
@@ -632,17 +634,18 @@ canvas.addEventListener("mousemove", function (event) {
       context.fillStyle = "#18ff03";
       circleHovered = true;
       const li = document.getElementById(`li-${i}`);
-      console.log(li);
+      
       li.style.backgroundColor = "#27941f";
       li.scrollIntoView({ behavior: "smooth", block: "center", scrollBehavior:"100ms"});
     } else {
       context.fillStyle = point.selectedItem;
       const li = document.getElementById(`li-${i}`);
-      console.log(li);
+      
     }
 
     context.fill();
   }
+}
 
   if (circleHovered) {
     canvas.style.cursor = "pointer";
@@ -715,6 +718,7 @@ helpButton.addEventListener("click", function () {
 });
 
 listButton.addEventListener("click", function () {
+  if (points.length > 0) {
   if (listContainer.style.display === "none") {
     closebuttons()
     listContainer.style.display = "block";
@@ -722,6 +726,7 @@ listButton.addEventListener("click", function () {
   } else {
     closebuttons()
   }
+}
 });
 
 newButton.addEventListener("click", function () {
@@ -881,6 +886,7 @@ function updatePointList() {
     li.id = `li-${index}`;
 
 li.addEventListener("mouseenter", () => {
+  if (!menuOpen){
   defaultlistcolour()
   // Change the color of the corresponding circle
   context.fillStyle = "#18ff03";
@@ -888,11 +894,199 @@ li.addEventListener("mouseenter", () => {
   context.arc(point.x, point.y, 15, 0, 2 * Math.PI);
   context.fill();
   li.style.backgroundColor = "#27941f";
+  }
 });
+
 li.addEventListener("mouseleave", () => {
+  if (!menuOpen){
   // Restore the color of the corresponding circle
   redrawCanvas();
   li.style.backgroundColor = "black";
+  }
+});
+
+li.addEventListener("click", (event) => {
+  const clickedElement = event.target;
+  const isBackgroundClicked = clickedElement === event.currentTarget;
+  const isLabelClicked = clickedElement.tagName.toLowerCase() === 'label';
+  if (!menuOpen && isBackgroundClicked || isLabelClicked) {
+  selectedPointIndex = index;
+        for (let j = 0; j < points.length; j++) {
+          const li = document.getElementById(`li-${j}`);
+          li.style.backgroundColor = j === selectedPointIndex ? "#27941f" : "#000000";
+        }
+        for (let i = 0; i < points.length; i++) {
+          context.beginPath();
+          context.arc(point.x, point.y, 6, 0, 2 * Math.PI);
+            defaultlistcolour()
+            context.fillStyle = "#18ff03";
+            context.fill();
+        }
+        const li = document.getElementById(`li-${selectedPointIndex}`);
+        console.log(li);
+        li.style.backgroundColor = "#27941f";
+
+        menuOpen = true;
+        // check if document.execCommand() is available before using it
+        copyToClipboard(point);
+        clickedCircle = true;
+        const menu = document.createElement("div");
+        menu.style.position = "absolute";
+        menu.style.top = "50%";
+        menu.style.left = "50%";
+        menu.style.transform = "translate(-50%, -50%)";
+        menu.style.backgroundColor = "#292929";
+        menu.style.border = "3px solid #141414";
+        menu.style.padding = "14px";
+        menu.style.display = "flex";
+        menu.style.flexDirection = "column";
+        menu.style.alignItems = "center";
+        menu.style.justifyContent = "center";
+
+        const coordinatesLabel = document.createElement("label");
+        coordinatesLabel.style.color = "#00ffff";
+        coordinatesLabel.style.marginBottom = "14px";
+        coordinatesLabel.textContent = "Copied to Clipboard:";
+
+        const coordinatesField = document.createElement("input");
+        coordinatesField.type = "text";
+        coordinatesField.value = `X: ${point.xCoord}, Y: ${point.yCoord}, Z: ${point.zCoord}`;
+        coordinatesField.style.width = "100%";
+        coordinatesField.style.marginBottom = "9px";
+        coordinatesField.style.textAlign = "center";
+        coordinatesField.style.backgroundColor = "#141414";
+        coordinatesField.style.color = "#fff";
+        coordinatesField.style.border = "none";
+        coordinatesField.style.padding = "9px";
+        coordinatesField.style.borderRadius = "3px";
+        coordinatesField.readOnly = true;
+
+        const noteLabel = document.createElement("label");
+        noteLabel.style.color = "#ffffff";
+        noteLabel.style.marginBottom = "14px";
+        noteLabel.textContent = `${point.note}`;
+
+        const buttonContainer = document.createElement("div");
+        buttonContainer.style.display = "flex";
+        buttonContainer.style.width = "100%";
+        buttonContainer.style.justifyContent = "space-between";
+
+        const closeButton = document.createElement("button");
+        closeButton.textContent = "Close";
+        closeButton.style.backgroundColor = "#00ffff";
+        closeButton.style.fontFamily = "BatlefieldFont";
+        closeButton.style.fontSize = "18px";
+        closeButton.style.marginTop = "5px";
+        closeButton.style.borderRadius = "4px";
+        closeButton.style.display = "inline-block";
+        closeButton.style.border = "3px";
+        closeButton.addEventListener("click", function () {
+          menu.remove();
+          menuOpen = false;
+          defaultlistcolour()
+          redrawCanvas()
+        });
+
+        const deleteButton = document.createElement("button");
+        deleteButton.textContent = "Delete";
+        deleteButton.style.backgroundColor = "#ff3838";
+        deleteButton.style.fontFamily = "BatlefieldFont";
+        deleteButton.style.fontSize = "18px";
+        deleteButton.style.marginTop = "5px";
+        deleteButton.style.borderRadius = "4px";
+        deleteButton.style.display = "inline-block";
+        deleteButton.style.border = "3px";
+        deleteButton.addEventListener("click", function () {
+          // Create a new menu element
+          const confirmMenu = document.createElement("div");
+          confirmMenu.style.position = "absolute";
+          confirmMenu.style.top = "0";
+          confirmMenu.style.left = "0";
+          confirmMenu.style.width = "100%";
+          confirmMenu.style.height = "100%";
+          confirmMenu.style.backgroundColor = "rgba(0, 0, 0, 0.85)";
+          confirmMenu.style.display = "flex";
+          confirmMenu.style.justifyContent = "center";
+          confirmMenu.style.alignItems = "center";
+          confirmMenu.style.flexDirection = "column";
+          confirmMenu.style.backdropFilter = "blur(10px)";
+          confirmMenu.style.zIndex = 2
+
+          // Create a message container element
+          const messageContainer = document.createElement("div");
+          messageContainer.style.textAlign = "center";
+          messageContainer.style.marginBottom = "20px";
+
+          // Create a message element
+          const message = document.createElement("div");
+          message.textContent = "Are you sure you want to delete?";
+          message.style.fontFamily = "BatlefieldFont";
+          message.style.fontSize = "24px";
+          message.style.color = "#fff";
+
+          // Create a confirm button
+          const confirmButton = document.createElement("button");
+          confirmButton.textContent = "Yes";
+          confirmButton.style.backgroundColor = "#ff3838";
+          confirmButton.style.fontFamily = "BatlefieldFont";
+          confirmButton.style.fontSize = "24px";
+          confirmButton.style.borderRadius = "4px";
+          confirmButton.style.border = "3px";
+          confirmButton.style.marginRight = "10px";
+          confirmButton.style.padding = "2px 13px";
+          confirmButton.addEventListener("click", function () {
+            // User confirmed deletion, perform the deletion process
+            points.splice(i, 1);
+            redrawCanvas();
+            confirmMenu.remove();
+            menu.remove();
+            menuOpen = false;
+            defaultlistcolour()
+          });
+
+          // Create a cancel button
+          const cancelButton = document.createElement("button");
+          cancelButton.textContent = "No";
+          cancelButton.style.backgroundColor = "#4CAF50";
+          cancelButton.style.fontFamily = "BatlefieldFont";
+          cancelButton.style.fontSize = "24px";
+          cancelButton.style.borderRadius = "4px";
+          cancelButton.style.border = "3px";
+          cancelButton.style.padding = "2px 13px";
+          cancelButton.addEventListener("click", function () {
+            // User canceled deletion, remove the confirm menu
+            confirmMenu.remove();
+          });
+
+          // Create a button container
+          const buttonContainer = document.createElement("div");
+          buttonContainer.style.display = "flex";
+          buttonContainer.style.justifyContent = "center";
+          buttonContainer.style.alignItems = "center";
+          buttonContainer.style.flexDirection = "row"; // Add this line to display buttons horizontally
+          buttonContainer.style.gap = "1.5rem"
+
+          // Add the message and buttons to their respective containers
+          messageContainer.appendChild(message);
+          buttonContainer.appendChild(confirmButton);
+          buttonContainer.appendChild(cancelButton);
+          confirmMenu.appendChild(messageContainer);
+          confirmMenu.appendChild(buttonContainer);
+
+          // Add the confirm menu to the page
+          document.body.appendChild(confirmMenu);
+        });
+
+        buttonContainer.appendChild(deleteButton);
+        buttonContainer.appendChild(closeButton);
+
+        menu.appendChild(coordinatesLabel);
+        menu.appendChild(coordinatesField);
+        menu.appendChild(noteLabel);
+        menu.appendChild(buttonContainer);
+
+        document.body.appendChild(menu);
+      }
 });
 
     const xCoordLabel = document.createElement("label");

--- a/Script.js
+++ b/Script.js
@@ -906,10 +906,11 @@ li.addEventListener("mouseleave", () => {
 });
 
 li.addEventListener("click", (event) => {
+  if (!menuOpen){
   const clickedElement = event.target;
   const isBackgroundClicked = clickedElement === event.currentTarget;
   const isLabelClicked = clickedElement.tagName.toLowerCase() === 'label';
-  if (!menuOpen && isBackgroundClicked || isLabelClicked) {
+  if (isBackgroundClicked || isLabelClicked) {
   selectedPointIndex = index;
         for (let j = 0; j < points.length; j++) {
           const li = document.getElementById(`li-${j}`);
@@ -1087,6 +1088,7 @@ li.addEventListener("click", (event) => {
 
         document.body.appendChild(menu);
       }
+  }
 });
 
     const xCoordLabel = document.createElement("label");

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <div id="headerContainer">
     <title>Battlefield Coordinate Finder 9000</title>
     <link href="./style.css" rel="stylesheet" type="text/css" />
     <meta property="og:title" content="Battlefield Coordinate Finder" />
@@ -20,7 +21,6 @@
   </head>
   <body>
     <span id="header-text">Battlefield Coordinate Finder 9000</span>
-    <hr/>
     <div id="buttons-container">
       <button id="new-button" class="newbutton">New</button>
       <div class="load-button-container">
@@ -32,8 +32,8 @@
       </div>
       <button id="help-button" class="helpbutton">Help</button>
     </div>
+  </div>
     <div id="new-options" style="display: none">
-      <hr/>
       <p>Select a map from the collection or import your own image</p>
       <div>
         <label for="game-mode">Game Mode: </label>
@@ -55,7 +55,6 @@
     </div>
 
     <div id="load-options" style="display: none">
-      <hr/>
       <p>Load a save file from the collection or import your own file</p>
       <div>
         <label for="game-mode-save">Game Mode: </label>
@@ -77,7 +76,6 @@
     </div>
 
     <div id="help-content" style="display: none">
-      <hr/>
       <p><strong>Controls:</strong></p>
       <p>Click on a space to create a position</p>
       <p>Coordinates are separated with spaces</p>

--- a/style.css
+++ b/style.css
@@ -10,7 +10,7 @@ body {
   display: flex;
   flex-direction: column;
   color: cyan;
-  padding: 0 5px;
+  padding: 0 0px;
   margin: 0;
   font-family: "BatlefieldFont", -apple-system, BlinkMacSystemFont, "Segoe UI",
     Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
@@ -44,6 +44,12 @@ a {
   align-items: center;
   margin: 0;
   gap: 0.3rem;
+  border-color: cyan;
+  border-top: solid;
+  border-bottom: solid;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  margin-top: 15px;
 }
 
 .load-button-container {
@@ -51,10 +57,10 @@ a {
 }
 
 #canvas-wrapper {
-  position: relative;
+  position: absolute;
   width: 100%;
   border: none;
-  height: calc(100vh - 115px); 
+  height: 100%;
   overflow: auto;
 }
 
@@ -102,11 +108,12 @@ a {
   margin-top: 0px;
   left: 105px;
   position: relative;
+  margin-bottom: 15px;
 }
 
 .extrabutton2 {
   position: absolute;
-  left: 476px; /* adjust this value to position the button horizontally */
+  left: 470px; /* adjust this value to position the button horizontally */
 }
 
 .helpbutton {
@@ -148,16 +155,46 @@ hr {
   margin: 10px auto 10px 0;
 }
 
+#new-options,
+#load-options,
+#help-content {
+overflow-y: auto;
+position: absolute;
+background-color: black;
+top: 110px;
+width: 560px;
+z-index: 1;
+border: cyan;
+border-bottom: solid;
+border-right: solid;
+}
+
+#headerContainer {
+  overflow-y: auto;
+  position: absolute;
+  background-color: black;
+  width: 560px;
+  z-index: 1;
+  border: cyan;
+  border-right: solid;
+}
+
 #pointListContainer {
   max-height: 28vh; /* or any other desired height */
   overflow-y: auto;
   left: -15px;
   position: absolute;
   background-color: black;
-  top: 110px;
+  top: 109px;
   width: 700px;
   z-index: 1;
+  border-color: cyan;
+  border-top: solid;
+  border-bottom: solid;
+  padding-top: 5px;
+  padding-bottom: 5px;
 }
+
 
 li {
   list-style: none;
@@ -186,7 +223,7 @@ li {
 }
 
 .listlabel {
-  padding-left: 20px;
+  margin-left: 20px;
 }
 
 input[type=number]::-webkit-outer-spin-button,


### PR DESCRIPTION
I have made the list clickable for the background and labels of the index with the following listener:

li.addEventListener("click", (event) => {
  const clickedElement = event.target;
  const isBackgroundClicked = clickedElement === event.currentTarget;
  const isLabelClicked = clickedElement.tagName.toLowerCase() === 'label';
  if (!menuOpen && isBackgroundClicked || isLabelClicked) {

Also made it that the list and dot colours do not update when the menus are open using the !openmenu check. 

The UI has been updated so that the UI in the top left now overlays the canvas so that the black space at the top is now usable. As a result the buttons for each category has been updated to also behave the same way and not push the canvas down the page.

As part of the UI update all the HR blocks have been removed and replaced with a border instead for a cleaner look.