### PR TITLE
Fixed issue by adding a timeout of 10ms

### DIFF
--- a/Script.js
+++ b/Script.js
@@ -943,8 +943,10 @@ li.addEventListener("mouseenter", () => {
 li.addEventListener("mouseleave", () => {
   if (!menuOpen){
   // Restore the color of the corresponding circle
-  redrawCanvas();
   li.style.backgroundColor = "black";
+  setTimeout(() => {
+    redrawCanvas();
+  }, 10);
   }
 });
 

--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
       <p>Contributors:</p>
       <p>Robert5974</p>
       <br>
-      <p>Version 1.4.1</p>
+      <p>Version 1.4.2</p>
     </div>
     <div id="canvas-wrapper">
       <img src="image.jpg" id="background-placeholer" />


### PR DESCRIPTION
The redraw canvas was being run too early and taking the point into account when redrawing the canvas and therefore not removing it.

Adding the setTimeout of 10ms has resolved the issue

li.addEventListener("mouseleave", () => {
  if (!menuOpen){
  li.style.backgroundColor = "black";
  setTimeout(() => {
    redrawCanvas();
  }, 10);
  }
});