### PR TITLE
Saving will convert image to JPEG

### DIFF
--- a/Script.js
+++ b/Script.js
@@ -673,9 +673,19 @@ saveProjectBtn.addEventListener("click", async function () {
   saveButton.style.backgroundColor = "rgb(0, 155, 155)";
   await new Promise(resolve => setTimeout(resolve, 10));
   context.drawImage(backgroundImage, 0, 0);
+  
+  // Create a new canvas for compressing the image as JPEG
+  const tempCanvas = document.createElement("canvas");
+  tempCanvas.width = canvas.width;
+  tempCanvas.height = canvas.height;
+  const tempContext = tempCanvas.getContext("2d");
+  tempContext.drawImage(backgroundImage, 0, 0);
+
+  const jpegDataUrl = tempCanvas.toDataURL("image/jpeg", 0.95);
+
   const data = {
     points: points,
-    image: canvas.toDataURL(),
+    image: jpegDataUrl,
   };
   const json = JSON.stringify(data);
   const blob = new Blob([json], { type: "application/json" });

--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
       <p>Contributors:</p>
       <p>Robert5974</p>
       <br>
-      <p>Version 1.4.3</p>
+      <p>Version 1.4.4</p>
     </div>
     <div id="canvas-wrapper">
       <img src="image.jpg" id="background-placeholer" />


### PR DESCRIPTION
This will now convert the image to  JPEG at a compression rate of 0.95 to retain image quality whilst keeping the file size within reason.  


```
saveButton.style.backgroundColor = "rgb(0, 155, 155)";
  await new Promise(resolve => setTimeout(resolve, 10));
  context.drawImage(backgroundImage, 0, 0);

  // Create a new canvas for compressing the image as JPEG
  const tempCanvas = document.createElement("canvas");
  tempCanvas.width = canvas.width;
  tempCanvas.height = canvas.height;
  const tempContext = tempCanvas.getContext("2d");
  tempContext.drawImage(backgroundImage, 0, 0);

  const jpegDataUrl = tempCanvas.toDataURL("image/jpeg", 0.95);

  const data = {
    points: points,
    image: jpegDataUrl,
```